### PR TITLE
Add openzeppelin and chainlink contract dependencies to brownie config

### DIFF
--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -58,4 +58,6 @@ hypothesis:
 
 autofetch_sources: false
 dependencies: null
+  - OpenZeppelin/openzeppelin-contracts@3.4.0
+  - smartcontractkit/chainlink@v0.9.10
 dev_deployment_artifacts: false

--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -32,7 +32,7 @@ compiler:
       runs: 200
     remappings:
       - openzeppelin=OpenZeppelin/openzeppelin-contracts@3.4.0
-      - chainlink=smartcontractkit/chainlink@v0.9.10
+      - chainlink=alphachainio/chainlink-contracts@1.1.2
   vyper:
     version: null
 
@@ -59,7 +59,7 @@ hypothesis:
     shrink: true
 
 autofetch_sources: false
-dependencies: null
+dependencies:
   - OpenZeppelin/openzeppelin-contracts@3.4.0
-  - smartcontractkit/chainlink@v0.9.10
+  - alphachainio/chainlink-contracts@1.1.2
 dev_deployment_artifacts: false

--- a/brownie-config.yaml
+++ b/brownie-config.yaml
@@ -30,7 +30,9 @@ compiler:
     optimizer:
       enabled: true
       runs: 200
-    remappings: null
+    remappings:
+      - openzeppelin=OpenZeppelin/openzeppelin-contracts@3.4.0
+      - chainlink=smartcontractkit/chainlink@v0.9.10
   vyper:
     version: null
 


### PR DESCRIPTION
# Description

This change includes minor fixes, where I added the openzeppelin and chainlink contracts as dependencies to the project. I also added path remappings so that compilation of contracts which import chainlink/openzeppelin contracts will result in a success.

Fixes #1 

## How Has This Been Tested?

No tests required, review the eth-brownie config file documentation at https://eth-brownie.readthedocs.io/en/stable/config.html for more information

## Reviews

- [ ] @med-amiine 
- [ ] @andykeh710 

## Checklist: (Please delete options that are not relevant)

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings